### PR TITLE
Improve input handling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -66,6 +66,10 @@ h1 {
   background: #2196f3;
   transform: scale(1.08);
 }
+.choice-btn.disabled {
+  pointer-events: none;
+  opacity: 0.6;
+}
 
 #feedback {
   font-size: 1.5rem;

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,7 @@ const STORAGE_KEY = 'violinQuizStats';
 /* --------------------------- state --------------------------- */
 let currentNote = null;
 let currentQuestionType = 'note'; // 'note' or 'stringFinger'
+let acceptingInput = true;
 let score = (function() {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) return { correct: 0, total: 0 };
@@ -86,6 +87,10 @@ function nextQuestion() {
   currentNote = NOTES[Math.floor(Math.random() * NOTES.length)];
   // Randomly choose question type
   currentQuestionType = Math.random() < 0.5 ? 'note' : 'stringFinger';
+
+  // Allow input for the new question
+  acceptingInput = true;
+
   
   // Show staff image for the note
   if (staffImg) {
@@ -107,12 +112,19 @@ function nextQuestion() {
   
   // Re-render choices for new question type
   renderChoices();
+
+  // Ensure buttons are enabled
+  document.querySelectorAll('.choice-btn').forEach(btn => btn.classList.remove('disabled'));
 }
 
 function checkAnswer(selectedId) {
+  if (!acceptingInput) return;
+  acceptingInput = false;
+
   const correct = selectedId === currentNote.id;
   feedback.textContent = correct ? '✅ Correct!' : `❌ Oops! It was ${currentNote.id}`;
   updateStats(correct);
+  document.querySelectorAll('.choice-btn').forEach(btn => btn.classList.add('disabled'));
   setTimeout(() => {
     feedback.textContent = '';
     nextQuestion();
@@ -120,9 +132,13 @@ function checkAnswer(selectedId) {
 }
 
 function checkStringFingerAnswer(selectedStringFinger) {
+  if (!acceptingInput) return;
+  acceptingInput = false;
+
   const correct = selectedStringFinger === currentNote.stringFinger;
   feedback.textContent = correct ? '✅ Correct!' : `❌ Oops! It was ${currentNote.stringFinger}`;
   updateStats(correct);
+  document.querySelectorAll('.choice-btn').forEach(btn => btn.classList.add('disabled'));
   setTimeout(() => {
     feedback.textContent = '';
     nextQuestion();


### PR DESCRIPTION
## Summary
- prevent multiple answers with new `acceptingInput` flag
- disable/enable buttons between questions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685734e43af0833195c52ff74cdf7e84